### PR TITLE
refactor: restore seconds for time-in-future

### DIFF
--- a/game/core/game_clock.py
+++ b/game/core/game_clock.py
@@ -24,5 +24,5 @@ class GameClock(BaseModel):
         return self
 
     @beartype
-    def get_time_in_future(self, milliseconds: int) -> datetime:
-        return self.current_time + timedelta(milliseconds=milliseconds)
+    def get_time_in_future(self, seconds: int | float) -> datetime:
+        return self.current_time + timedelta(milliseconds=int(seconds * 1000))

--- a/game/core/gui/main.py
+++ b/game/core/gui/main.py
@@ -28,7 +28,7 @@ class GameGUI:
         self.game_clock = game_clock
         self.pressed_keys = pressed_keys
         self.message_box = MessageBox(window_shape)
-        self._close_message_box_time = self.game_clock.get_time_in_future(5000)
+        self._close_message_box_time = self.game_clock.get_time_in_future(5)
 
     @beartype
     def draw(self) -> None:
@@ -52,8 +52,7 @@ class GameGUI:
         notes: str = "",
         seconds: int = _default_seconds_to_show_message_box,
     ) -> None:
-        milliseconds = seconds * 1000
-        self._close_message_box_time = self.game_clock.get_time_in_future(milliseconds)
+        self._close_message_box_time = self.game_clock.get_time_in_future(seconds)
         self.message_box.message = message
         self.message_box.notes = notes
         self._show_message_box = True

--- a/game/core/gui/rpg_movement.py
+++ b/game/core/gui/rpg_movement.py
@@ -39,7 +39,7 @@ class RPGMovement:
         pressed_keys: PressedKeys,
     ) -> None:
         self.game_clock = game_clock
-        self.next_save = self.game_clock.get_time_in_future(200)
+        self.next_save = self.game_clock.get_time_in_future(0.2)
         self.game_map = game_map
         self.state = state
         self.gui = gui
@@ -94,7 +94,7 @@ class RPGMovement:
         # Cap saving to once per second
         if self.game_clock.current_time > self.next_save:
             self.state.save_player_data(self.player_sprite)
-            self.next_save = self.game_clock.get_time_in_future(200)
+            self.next_save = self.game_clock.get_time_in_future(0.2)
 
     def on_mouse_press(self, x, y, button, key_modifiers) -> None:
         """Called when the user presses a mouse button."""


### PR DESCRIPTION
Quick refactor to restore seconds instead of milliseconds! Generally, we only care about the former, but we can handle floats with this change, which can be useful

Haha, I pushed this change just as you merged the PR!